### PR TITLE
Enable eslint loader

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -8,7 +8,8 @@
   "rules": {
     "no-confusing-arrow": "off",
     "no-else-return": "off",
-    "max-len": ["error", 120]
+    "max-len": ["error", 120],
+    "no-unused-vars": ["error", {"args": "none"}]
   },
   "settings": {
     "import/resolver": "webpack"

--- a/.eslintrc
+++ b/.eslintrc
@@ -3,8 +3,14 @@
   "env": {
     "mocha": true
   },
+  "plugins": ["react"],
   "parser": "babel-eslint",
   "rules": {
-    "no-confusing-arrow": 0
+    "no-confusing-arrow": "off",
+    "no-else-return": "off",
+    "max-len": ["error", 120]
+  },
+  "settings": {
+    "import/resolver": "webpack"
   }
 }

--- a/package.json
+++ b/package.json
@@ -42,6 +42,8 @@
     "css-loader": "^0.23.1",
     "eslint": "^2.9.0",
     "eslint-config-airbnb": "^8.0.0",
+    "eslint-import-resolver-webpack": "^0.2.1",
+    "eslint-loader": "^1.3.0",
     "eslint-plugin-import": "^1.6.1",
     "eslint-plugin-jsx-a11y": "^1.0.4",
     "eslint-plugin-react": "5.0.1",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -15,7 +15,7 @@ module.exports = {
   module: {
     preLoaders: [
       // Eslint loader
-      // { test: /\.(js|jsx)$/, exclude: /node_modules/, loader: 'eslint-loader'},
+      { test: /\.(js|jsx)$/, exclude: /node_modules/, loader: 'eslint-loader'},
     ],
     loaders: [
       { test: /\.html$/, loader: 'file?name=[name].[ext]' },


### PR DESCRIPTION
Reasons for some of the ESLint settings:
- `no-else-return`:
  
  I think `else`-`return` should be preferred if the conditional represents two non-trivial opposites, such as:
  
  ```
  if (ui.isPreviewing) {
    return <Preview />;
  } else {
    return <Workspace />;
  }
  ```
  
  When this setting is enabled, the following is enforced:
  
  ```
  if (ui.isPreviewing) {
    return <some jsx />;
  }
  
  return <Workspace />;
  ```
- `no-unused-vars`:
  
  Disabling this allows you to document parameters in library APIs like the following without ESLint complaining about unused variables in your signatures:
  
  ```
  const p = new Promise((resolve, reject) =>
    resolve(/* ... */)
  );
  ```
