### PR TITLE
Add karma-phantomjs-shim

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -13,7 +13,11 @@ module.exports = function(config) {
 
     // frameworks to use
     // available frameworks: https://npmjs.org/browse/keyword/karma-adapter
-    frameworks: ['mocha', 'chai'],
+    frameworks: [
+      'mocha',
+      'chai',
+      'phantomjs-shim'
+    ],
 
 
     // list of files / patterns to load in the browser
@@ -67,7 +71,8 @@ module.exports = function(config) {
       require('karma-webpack'),
       'karma-chai',
       'karma-mocha',
-      'karma-phantomjs-launcher'
+      'karma-phantomjs-launcher',
+      'karma-phantomjs-shim'
     ]
   })
 }

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "karma-chai": "^0.1.0",
     "karma-mocha": "^0.2.2",
     "karma-phantomjs-launcher": "^1.0.0",
+    "karma-phantomjs-shim": "^1.3.0",
     "karma-webpack": "^1.7.0",
     "mocha": "^2.4.5",
     "phantomjs-prebuilt": "^2.1.7",


### PR DESCRIPTION
Provides shims for functions like `Function.prototype.bind`, `Object.assign` and `String.prototype.startsWith`, without which may cause tests to stop working.
