### PR TITLE
Make JSX boolean attributes explicit

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -9,7 +9,8 @@
     "no-confusing-arrow": "off",
     "no-else-return": "off",
     "max-len": ["error", 120],
-    "no-unused-vars": ["error", {"args": "none"}]
+    "no-unused-vars": ["error", {"args": "none"}],
+    "react/jsx-boolean-value": ["error", "always"]
   },
   "settings": {
     "import/resolver": "webpack"

--- a/src/todos/components/Footer.js
+++ b/src/todos/components/Footer.js
@@ -60,7 +60,7 @@ class Footer extends Component {
       return (
         <RaisedButton
           className="clear-completed"
-          primary
+          primary={true}
           label="Clear completed"
           onClick={onClearCompleted}
         />

--- a/src/todos/components/Header.js
+++ b/src/todos/components/Header.js
@@ -23,7 +23,7 @@ class Header extends Component {
       <header className="header">
         <h1 style={defaultStyle}>todos</h1>
         <TodoTextInput
-          newTodo
+          newTodo={true}
           onSave={this.handleSave}
           placeholder="What needs to be done?"
         />


### PR DESCRIPTION
I suggest requiring boolean attributes to be explicitly written. This means that people new to JSX don't have to look up what it means. It also keeps the style consistent:

``` jsx
<Component
  key={value}
  key2={true}
  key3={value3}
/>
```

instead of the lopsided:

``` jsx
<Component
  key={value}
  key2
  key3={value3}
/>
```

Merging this change into this project is only a suggestion;  we're enabling this in green's projects because we prefer the benefits of it being there.
